### PR TITLE
remove dependancy on wrapr package and favour rlang instead

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,6 @@ Imports:
   partykit (>= 1.0.5),
   purrr (>= 0.2.2),
   stringr (>= 1.2.0),
-  wrapr (>= 0.4.2),
   forcats(>= 0.2.0),
   cowplot(>= 0.8.0)
 License: GPL (>= 2)

--- a/R/build_iv_table.R
+++ b/R/build_iv_table.R
@@ -1,22 +1,22 @@
 build_iv_table <- function(dframe, y = "gb12"){
+  y_sym = as.symbol(y)
+
   total_goods <- sum(dframe[[y]] == 0)
   total_bads <- sum(dframe[[y]] == 1)
   total_log_odds <- log(total_bads / total_goods)
 
-  iv_table <- wrapr::let(list(.y. = y), {
-    dframe %>%
-      group_by(group) %>%
-      summarise(freq = n(),
-                freq_bad = sum(.y. == 1),
-                freq_good = sum(.y. == 0)) %>%
-      mutate(prop_total = freq / sum(freq),
-             bad_rate = freq_bad / freq,
-             odds = freq_bad / freq_good,
-             log_odds = log(odds),
-             woe = log_odds - total_log_odds,
-             iv = (freq_bad/total_bads - freq_good/total_goods) * woe) %>%
-      mutate_if(is.numeric, ~ round(.x, 5))
-  }) %>%
+  iv_table <- dframe %>%
+    group_by(group) %>%
+    summarise(freq = n(),
+              freq_bad = sum((!!y_sym) == 1),
+              freq_good = sum((!!y_sym) == 0)) %>%
+    mutate(prop_total = freq / sum(freq),
+           bad_rate = freq_bad / freq,
+           odds = freq_bad / freq_good,
+           log_odds = log(odds),
+           woe = log_odds - total_log_odds,
+           iv = (freq_bad/total_bads - freq_good/total_goods) * woe) %>%
+    mutate_if(is.numeric, ~ round(.x, 5)) %>%
     mutate(group = forcats::fct_explicit_na(group))
 
   attr(iv_table$group, "class") <- "factor"


### PR DESCRIPTION
Previous to the release of `dplyr v0.7+` this package was using `wrapr::let` blocks to do programming with `dplyr` functions. This removes these in favour of `rlang` solutions to these problems.