### PR TITLE
remove default y column named gb12

### DIFF
--- a/R/bin_all.R
+++ b/R/bin_all.R
@@ -1,7 +1,7 @@
 #' Bin All Features in a Dataframe
 #' 
 #' @export 
-bin_all <- function(dframe, y = "gb12", vars_to_exclude, vars_to_include, bins = NULL, tree_control = ctree_control(), verbose = FALSE){
+bin_all <- function(dframe, y, vars_to_exclude, vars_to_include, bins = NULL, tree_control = ctree_control(), verbose = FALSE){
   features_to_bin <- setdiff(names(dframe), y)
 
   if(!missing(vars_to_exclude)){

--- a/R/bin_factor.R
+++ b/R/bin_factor.R
@@ -1,5 +1,5 @@
 #' @importFrom partykit ctree_control
-bin_factor <- function(dframe, x, y = "gb12", supervised = FALSE, tree_control = ctree_control()){
+bin_factor <- function(dframe, x, y, supervised = FALSE, tree_control = ctree_control()){
   feature_is_ordered <- "ordered" %in% class(dframe[[x]])
 
   feature_type <- if(feature_is_ordered) "ordered_factor" else "factor"

--- a/R/bin_numeric.R
+++ b/R/bin_numeric.R
@@ -7,7 +7,7 @@
 #' @importFrom purrr map
 #' @importFrom purrr discard
 #' @importFrom purrr flatten_dbl
-bin_numeric <- function(dframe, x, y = "gb12",
+bin_numeric <- function(dframe, x, y,
                         tree_control = ctree_control(), bins = NULL){
   FEATURE_TYPE <- 'numeric'
 
@@ -112,7 +112,7 @@ plot.binned_numeric <- function(binned_feature, old_frame, y = 'gb12'){
                        nrow = 2)
 }
 
-create_numeric_supervised_bins <- function(dframe, x, y = "gb12", tree_control = ctree_control()){
+create_numeric_supervised_bins <- function(dframe, x, y, tree_control = ctree_control()){
   x_sym <- as.symbol(x)
   y_sym <- as.symbol(y)
 

--- a/R/build_iv_table.R
+++ b/R/build_iv_table.R
@@ -1,4 +1,4 @@
-build_iv_table <- function(dframe, y = "gb12"){
+build_iv_table <- function(dframe, y){
   y_sym = as.symbol(y)
 
   total_goods <- sum(dframe[[y]] == 0)

--- a/R/build_miv_tables.R
+++ b/R/build_miv_tables.R
@@ -1,4 +1,4 @@
-build_miv_tables <- function(dframe, y = "gb12", pd = "pd"){
+build_miv_tables <- function(dframe, y, pd = "pd"){
   pd_sym = as.symbol(pd)
 
   total_goods <- sum(dframe[[y]] == 0)

--- a/R/calculate_all_mivs.R
+++ b/R/calculate_all_mivs.R
@@ -1,7 +1,7 @@
 #' @importFrom purrr map_dbl
 #'
 #' @export
-calculate_all_mivs <- function(dframe, y = "gb12", pd = "pd", vars_to_exclude,
+calculate_all_mivs <- function(dframe, y, pd = "pd", vars_to_exclude,
                                vars_to_include, as_dframe = TRUE){
   features_to_bin <- setdiff(names(dframe), c(y, pd))
 
@@ -26,7 +26,7 @@ calculate_all_mivs <- function(dframe, y = "gb12", pd = "pd", vars_to_exclude,
   arrange(desc(miv))
 }
 
-calculate_miv <- function(dframe, binned_x, y = "gb12", pd = "pd"){
+calculate_miv <- function(dframe, binned_x, y, pd = "pd"){
   feature_is_categorical <- dframe[[binned_x]] %>% {is.character(.) | is.factor(.)}
 
   if(!feature_is_categorical){

--- a/tests/testthat/test_bin_all.R
+++ b/tests/testthat/test_bin_all.R
@@ -9,7 +9,7 @@ test_that("bin_all creates binned_objects for corresponding feature data type", 
   example_data <- german_credit_data %>%
     select(ca_status, age, property, gb12)
 
-  binned_objects <- bin_all(example_data)
+  binned_objects <- bin_all(example_data, "gb12")
   binned_object_classes <- binned_objects %>%
     purrr::map_chr(~ class(.x)[1]) %>%
     setNames(NULL)
@@ -24,7 +24,7 @@ test_that("variables can be excluded from the binning process", {
     bin_factor = function(dframe, xvar, y, supervised, tree_control) "factor binning",
     bin_numeric = function(dframe, xvar, y, tree_control, bins) "numeric binning",
     {
-      binned_objects <- bin_all(data_for_binning, vars_to_exclude = c("b", "c"))
+      binned_objects <- bin_all(data_for_binning, "gb12", ,vars_to_exclude = c("b", "c"))
       expect_equal(names(binned_objects), "a")
     }
   )
@@ -35,7 +35,7 @@ test_that("user can specify that only certain variables are binned", {
     bin_factor = function(dframe, xvar, y, supervised, tree_control) "factor binning",
     bin_numeric = function(dframe, xvar, y, tree_control, bins) "numeric binning",
     {
-      binned_objects <- bin_all(data_for_binning, vars_to_include = c("b", "c"))
+      binned_objects <- bin_all(data_for_binning, "gb12", vars_to_include = c("b", "c"))
       expect_equal(names(binned_objects), c("b", "c"))
     }
   )
@@ -66,7 +66,7 @@ test_that("the tree_control argument is passed to the atomic binning functions",
     },
     {
   
-      binned_objects <- bin_all(data_for_binning, tree_control = control_val)
+      binned_objects <- bin_all(data_for_binning, "gb12", tree_control = control_val)
       expect_equal(binned_objects, expected_output)
     }
   )
@@ -85,7 +85,7 @@ test_that("bin_all passes the bins function to bin_numeric", {
       bins
     },
     {
-      binned_objects <- bin_all(data_for_binning, bins = n_bins)
+      binned_objects <- bin_all(data_for_binning, "gb12", bins = n_bins)
       expect_equal(binned_objects$a, n_bins)
     }
   )
@@ -105,7 +105,7 @@ test_that("if number of bins is specified in bin_all then categorical binning
       supervised
     },
     {
-      binned_objects <- bin_all(data_for_binning, bins = n_bins)
+      binned_objects <- bin_all(data_for_binning, "gb12", bins = n_bins)
       categorical_binning_was_supervised <- binned_objects$a
       expect_false(categorical_binning_was_supervised)
     }
@@ -124,7 +124,7 @@ test_that("if number of bins is specified in bin_all then categorical binning
       supervised
     },
     {
-      binned_objects <- bin_all(data_for_binning)
+      binned_objects <- bin_all(data_for_binning, "gb12")
       categorical_binning_was_supervised <- binned_objects$a
       expect_true(categorical_binning_was_supervised)
     }
@@ -144,7 +144,7 @@ test_that("bin_all prints which variables are being binned if verbose = TRUE", {
   with_mock(
     bin_numeric = function(dframe, xvar, y, tree_control, bins) "numeric binning",
     {
-      expect_output(bin_all(data_for_binning, verbose = TRUE), regexp = expected_message)
+      expect_output(bin_all(data_for_binning, "gb12", verbose = TRUE), regexp = expected_message)
     }
   )
 })

--- a/tests/testthat/test_bin_factor.R
+++ b/tests/testthat/test_bin_factor.R
@@ -1,6 +1,6 @@
-binned_feature <- bin_factor(german_credit_data, x = "property")
+binned_feature <- bin_factor(german_credit_data, x = "property", y = "gb12")
 
-supervised_ordered_binned_feature <- bin_factor(german_credit_data, x = "present_employment_since", supervised = TRUE)
+supervised_ordered_binned_feature <- bin_factor(german_credit_data, x = "present_employment_since", y = "gb12", supervised = TRUE)
 
 test_that("bin_factor creates an object of class binned_categorical", {
   expect_is(binned_feature, "binned_factor")
@@ -28,14 +28,14 @@ test_that("if the feature that was binned is an ordered factor,
                                               levels = employment_status_levels,
                                               ordered = TRUE))
 
-  ordered_binned_feature <- bin_factor(german_data_w_ordered_col, x = "present_employment_since")
+  ordered_binned_feature <- bin_factor(german_data_w_ordered_col, x = "present_employment_since", y = "gb12")
 
   expect_equal(sort(ordered_binned_feature$iv_table$group), ordered_binned_feature$iv_table$group)
 })
 
 test_that("if supervised binning is requested then a supervised binning algorithm is used
            to group the factor levels", {
-  supervised_binned_feature <- bin_factor(german_credit_data, x = "property", supervised = TRUE)
+  supervised_binned_feature <- bin_factor(german_credit_data, x = "property", y = "gb12", supervised = TRUE)
 
   expected_names <- c("feature", "feature_type", "levels", "node_groups", "tree", "iv", "iv_table")
 
@@ -44,11 +44,12 @@ test_that("if supervised binning is requested then a supervised binning algorith
 })
 
 test_that("tree_control can be used to pass parameters to ctree algorithm used for binning", {
-  binned_feature <- bin_factor(german_credit_data, x = "property", supervised = TRUE)
+  binned_feature <- bin_factor(german_credit_data, x = "property", y = "gb12", supervised = TRUE)
 
   bin_with_small_tree <- bin_factor(
     german_credit_data,
     x = "property",
+    y = "gb12",
     supervised = TRUE,
     tree_control = ctree_control(maxdepth = 1)
   )
@@ -64,7 +65,7 @@ describe("predict.binned_factor()", {
   mutate(property = property %>% replace(. == "car or other", "xcar or other"))
 
   describe("when non-supervised binning is used to create the binned factor", {
-    binned_feature <- bin_factor(german_credit_data, x = feature_to_bin)
+    binned_feature <- bin_factor(german_credit_data, x = feature_to_bin, y = "gb12") 
 
     it("reorders the factor levels to have the largest category first", {
       data_with_binned_feature <- predict(binned_feature, german_credit_data)
@@ -75,7 +76,7 @@ describe("predict.binned_factor()", {
   })
 
   describe("when supervised binning was used to create the binned_factor", {    
-    binned_feature <- bin_factor(german_credit_data, x = feature_to_bin, supervised = TRUE)
+    binned_feature <- bin_factor(german_credit_data, x = feature_to_bin, y = "gb12", supervised = TRUE)
 
     it("applies the categorical groupings to the relevant column with the largest category as the first group", {
       data_with_binned_feature <- predict(binned_feature, german_credit_data)
@@ -86,7 +87,7 @@ describe("predict.binned_factor()", {
   })
 
   describe("largest_level_first is false", {
-    binned_feature <- bin_factor(german_credit_data, x = feature_to_bin)
+    binned_feature <- bin_factor(german_credit_data, x = feature_to_bin, y = "gb12") 
     data_with_binned_feature <- predict(binned_feature, german_credit_data, largest_level_first = FALSE)
 
     it("does not reorder the factor levels to have the largest first", {
@@ -100,7 +101,7 @@ describe("predict.binned_factor()", {
 test_that("binned_factor objects have a predict method, if supervised binning was used for the binning
            process the category groupings is applied to the relevant column", {
   feature_to_bin <- "property"
-  binned_feature <- bin_factor(german_credit_data, x = feature_to_bin, supervised = TRUE)
+  binned_feature <- bin_factor(german_credit_data, x = feature_to_bin, y = "gb12", supervised = TRUE)
 
   data_with_binned_feature <- predict(binned_feature, german_credit_data)
   binned_levels <- binned_feature$levels
@@ -111,7 +112,7 @@ test_that("binned_factor objects have a predict method, if supervised binning wa
 
 test_that("the binned_factor predict method works with features other than property", {
   feature_to_bin <- "ca_status"
-  binned_feature <- bin_factor(german_credit_data, x = feature_to_bin, supervised = TRUE)
+  binned_feature <- bin_factor(german_credit_data, x = feature_to_bin, y = "gb12", supervised = TRUE)
 
   data_with_binned_feature <- predict(binned_feature, german_credit_data)
   binned_levels <- binned_feature$levels
@@ -120,7 +121,7 @@ test_that("the binned_factor predict method works with features other than prope
 })
 
 test_that("binned_factor objects have a plot method that creates a graph with 3 elements", {
-  binned_feature <- bin_factor(german_credit_data, x = "property")
+  binned_feature <- bin_factor(german_credit_data, x = "property", y = "gb12")
   binned_feature_plot <- plot(binned_feature)
 
   expect_equal(length(binned_feature_plot$layers), 3)
@@ -128,7 +129,7 @@ test_that("binned_factor objects have a plot method that creates a graph with 3 
 })
 
 test_that("if the original data set is also passed to the plot method the plot has 4 elements", {
-  binned_feature <- bin_factor(german_credit_data, x = "property")
+  binned_feature <- bin_factor(german_credit_data, x = "property", y = "gb12")
   binned_feature_plot <- plot(binned_feature, german_credit_data)
 
   expect_equal(length(binned_feature_plot$layers), 4)

--- a/tests/testthat/test_bin_numeric.R
+++ b/tests/testthat/test_bin_numeric.R
@@ -1,4 +1,4 @@
-binned_feature <- bin_numeric(german_credit_data, x = "credit_amount")
+binned_feature <- bin_numeric(german_credit_data, x = "credit_amount", y = "gb12")
 
 test_that("bin_numeric creates an object of class binned_numeric", {
   expect_is(binned_feature, "binned_numeric")
@@ -23,7 +23,7 @@ test_that("bin_numeric can accept different names for y variable", {
 test_that("if no significant splits are found, this is reported", {
   x <- "existing_credits"
 
-  binned_feature <- bin_numeric(german_credit_data, x = x)
+  binned_feature <- bin_numeric(german_credit_data, x = x, y = "gb12")
   expected_output <- list(
     feature = x,
     feature_type = "numeric",
@@ -34,11 +34,12 @@ test_that("if no significant splits are found, this is reported", {
 })
 
 test_that("tree_control can be used to pass parameters to ctree algorithm used for binning", {
-  binned_feature <- bin_numeric(german_credit_data, x = "credit_amount")
+  binned_feature <- bin_numeric(german_credit_data, x = "credit_amount", y = "gb12")
 
   bin_with_small_tree <- create_numeric_supervised_bins(
     german_credit_data,
     x = "credit_amount",
+    y = "gb12",
     tree_control = ctree_control(maxdepth = 1)
   )
 
@@ -50,7 +51,7 @@ test_that("if a bins argument is provided, bin_numeric creates specified number 
   #example 1
   n_bins <- 5
 
-  binned_feature <- bin_numeric(german_credit_data, x = "credit_amount", bins = n_bins)
+  binned_feature <- bin_numeric(german_credit_data, x = "credit_amount", y = "gb12", bins = n_bins)
   binned_iv_table <- binned_feature$iv_table
   bins_are_all_roughly_equal_check <- all(
     round(binned_iv_table$freq / 1000, 2) == ((sum(binned_iv_table$freq) / n_bins) / 1000)
@@ -62,7 +63,7 @@ test_that("if a bins argument is provided, bin_numeric creates specified number 
   #example 2
   n_bins <- 10
 
-  binned_feature <- bin_numeric(german_credit_data, x = "credit_amount", bins = n_bins)
+  binned_feature <- bin_numeric(german_credit_data, x = "credit_amount", y = "gb12", bins = n_bins)
 
   expect_equal(length(binned_feature$levels), n_bins)
 })
@@ -70,7 +71,7 @@ test_that("if a bins argument is provided, bin_numeric creates specified number 
 test_that("if there are less unique values than bins requested, create_numeric_frequency_bins
            uses the unique values as cutpoints", {
   #the feature being binned takes four unique values
-  binned_feature <- bin_numeric(german_credit_data, x = "installment_rate_income", bins = 5)
+  binned_feature <- bin_numeric(german_credit_data, x = "installment_rate_income", y = "gb12", bins = 5)
   binned_groups <- binned_feature$iv_table$group
   expected_groups <- c("(,1]", "(1,2]", "(2,3]", "(3,]") %>% {factor(., levels = .)}
 
@@ -86,7 +87,7 @@ test_that("if bins is not an integer >= 2 an error is raised", {
 
 describe("predict.binned_numeric()", {
   feature_to_bin <- "duration"
-  binned_feature <- bin_numeric(german_credit_data, x = feature_to_bin)
+  binned_feature <- bin_numeric(german_credit_data, x = feature_to_bin, y = "gb12")
 
   it("bins the relevant features with the largest category in the factor as the first level", {
     df_with_binned_feature <- predict(binned_feature, german_credit_data)
@@ -108,7 +109,7 @@ describe("predict.binned_numeric()", {
 })
 
 test_that("binned_numeric objects has a plot method that creates a graph with 3 elements", {
-  binned_feature <- bin_numeric(german_credit_data, x = "credit_amount")
+  binned_feature <- bin_numeric(german_credit_data, x = "credit_amount",  y = "gb12")
   binned_feature_plot <- plot(binned_feature)
 
   expect_equal(length(binned_feature_plot$layers), 3)
@@ -116,7 +117,7 @@ test_that("binned_numeric objects has a plot method that creates a graph with 3 
 })
 
 test_that("if the original data set is also passed to the plot method the plot has 4 elements", {
-  binned_feature <- bin_numeric(german_credit_data, x = "credit_amount")
+  binned_feature <- bin_numeric(german_credit_data, x = "credit_amount",  y = "gb12")
   binned_feature_plot <- plot(binned_feature, german_credit_data)
 
   expect_equal(length(binned_feature_plot$layers), 4)

--- a/tests/testthat/test_build_iv_table.R
+++ b/tests/testthat/test_build_iv_table.R
@@ -12,7 +12,7 @@ grouped_ca_status <- readr::read_csv(
 test_that("given a dataframe with a column called group containing a categorical variable
            and a column column entitled gb12 response, build_iv_table will costruct
            a table calculating information values", {
-  iv_table <- build_iv_table(grouped_ca_status)
+  iv_table <- build_iv_table(grouped_ca_status, y = "gb12")
   expected_iv_table <- tibble::tribble(
            ~group, ~freq, ~freq_bad, ~freq_good, ~prop_total, ~bad_rate,   ~odds, ~log_odds,     ~woe,     ~iv,
         "No Acc.",   394,        46,        348,       0.394,   0.11675, 0.13218,  -2.02356, -1.17626, 0.40441,
@@ -29,7 +29,7 @@ test_that("if some data is missing from the group feature, this is reported as a
            which is the bottom row of the data", {
   grouped_ca_status$group[1:100] <- NA
 
-  iv_table <- build_iv_table(grouped_ca_status)
+  iv_table <- build_iv_table(grouped_ca_status, y = "gb12")
   expected_iv_table <- data_frame(
     group = c("No Acc.", "(;0DM)", "<0DM;200DM)", "<200DM;)", "(Missing)"),
     iv = c(0.35346, 0.20804, 0.04803, 0.00726, 0.00598)

--- a/tests/testthat/test_build_miv_tables.R
+++ b/tests/testthat/test_build_miv_tables.R
@@ -41,7 +41,7 @@ test_that("given a dataframe with a column called group containing a categorical
            a response variable entitled gb12 and a column entitled pd containing
            pds from a previous model description, build_miv_tables will calculate
            partial miv values", {
-  miv_tables <- build_miv_tables(grouped_ca_status)
+  miv_tables <- build_miv_tables(grouped_ca_status, y = "gb12")
 
   expect_equal(names(miv_tables), c("actual_woe", "expected_woe", "miv_table"))
   expect_equal(miv_tables$actual_woe, actual_woe_table_expected)
@@ -54,7 +54,7 @@ test_that("if some data is missing from the group feature, build_miv_tables crea
   grouped_ca_status$group[1:100] <- NA
 
 
-  miv_tables <- build_miv_tables(grouped_ca_status)
+  miv_tables <- build_miv_tables(grouped_ca_status, y = "gb12")
   expected_table_categories <- c("No Acc.", "(;0DM)", "<0DM;200DM)", "<200DM;)", "(Missing)") %>%
     factor(., levels = .)
 

--- a/tests/testthat/test_calculate_all_mivs.R
+++ b/tests/testthat/test_calculate_all_mivs.R
@@ -10,7 +10,7 @@ credit_data_w_pd <- credit_data_small %>%
 test_that("given a data frame with a response variable named gb12
            and pd predictions from a previous model,
            calculate_all_mivs calculates the marginal iv for all variables", {
-  miv_output <- calculate_all_mivs(credit_data_w_pd)
+  miv_output <- calculate_all_mivs(credit_data_w_pd, y = "gb12")
 
   expected_output <- data_frame(
     feature_name = c("credit_history", "purpose", "ca_status"),
@@ -26,7 +26,7 @@ test_that("the feature data types can be factor or character", {
   #so we need to test a factor variable
   credit_data_w_pd$purpose <- factor(credit_data_w_pd$purpose)
 
-  expect_error(calculate_all_mivs(credit_data_w_pd), NA)
+  expect_error(calculate_all_mivs(credit_data_w_pd, y = "gb12"), NA)
 })
 
 test_that("if numeric variables are included an error is thrown", {
@@ -35,14 +35,14 @@ test_that("if numeric variables are included an error is thrown", {
   credit_data_w_pd <- bind_rows(credit_data_w_pd, numeric_col)
 
   expect_error(
-    calculate_all_mivs(credit_data_w_pd),
+    calculate_all_mivs(credit_data_w_pd, y = "gb12"),
     "cannot calculate miv for a non-categorical variable"
   )
 })
 
 test_that("if as_dframe = FALSE a detailed output of the miv calculations
            is presented in list form", {
-  miv_output <- calculate_all_mivs(credit_data_w_pd, as_dframe = FALSE)
+  miv_output <- calculate_all_mivs(credit_data_w_pd, y = "gb12", as_dframe = FALSE)
   expected_output_names <- c("actual_woe", "expected_woe",
                              "miv_table", "iv", "miv")
 
@@ -52,15 +52,14 @@ test_that("if as_dframe = FALSE a detailed output of the miv calculations
 })
 
 test_that("user can specify which variables are excluded in the calculation", {
-  miv_output <- calculate_all_mivs(credit_data_w_pd, vars_to_exclude = "purpose")
+  miv_output <- calculate_all_mivs(credit_data_w_pd, y = "gb12", vars_to_exclude = "purpose")
   expected_features_included <- c("credit_history", "ca_status")
 
   expect_equal(miv_output$feature_name, expected_features_included)
 })
 
 test_that("user can specify which variables are included in the calculation", {
-  miv_output <- calculate_all_mivs(credit_data_w_pd,
-                                   vars_to_include = c("ca_status", "purpose"))
+  miv_output <- calculate_all_mivs(credit_data_w_pd, y = "gb12", vars_to_include = c("ca_status", "purpose"))
 
   expected_features_included <- c("purpose", "ca_status")
 


### PR DESCRIPTION
This PR stops functions assuming a default `gb12` y variable