### PR TITLE
pass predictions as own vector into calculate_all_mivs

### DIFF
--- a/R/build_miv_tables.R
+++ b/R/build_miv_tables.R
@@ -1,5 +1,5 @@
-build_miv_tables <- function(dframe, y, pd = "pd"){
-  pd_sym = as.symbol(pd)
+build_miv_tables <- function(dframe, y, predictions){
+  dframe$.predictions. <- predictions
 
   total_goods <- sum(dframe[[y]] == 0)
   total_bads <- sum(dframe[[y]] == 1)
@@ -11,8 +11,8 @@ build_miv_tables <- function(dframe, y, pd = "pd"){
   expected_woe <- dframe %>%
     group_by(group) %>%
     summarise(freq = n(),
-              freq_bad = sum(!!pd_sym),
-              freq_good = sum(1 - (!!pd_sym))) %>%
+              freq_bad = sum(.predictions.),
+              freq_good = sum(1 - (.predictions.))) %>%
     mutate(prop_total = freq / sum(freq),
            bad_rate = freq_bad / freq,
            odds = freq_bad / freq_good,

--- a/R/calculate_all_mivs.R
+++ b/R/calculate_all_mivs.R
@@ -1,9 +1,10 @@
 #' @importFrom purrr map_dbl
 #'
 #' @export
-calculate_all_mivs <- function(dframe, y, pd = "pd", vars_to_exclude,
+calculate_all_mivs <- function(dframe, y, predictions, vars_to_exclude,
                                vars_to_include, as_dframe = TRUE){
-  features_to_bin <- setdiff(names(dframe), c(y, pd))
+  predictions <- as.vector(predictions)
+  features_to_bin <- setdiff(names(dframe), y)
 
   if(!missing(vars_to_exclude)){
     features_to_bin <- setdiff(features_to_bin, vars_to_exclude)
@@ -13,7 +14,7 @@ calculate_all_mivs <- function(dframe, y, pd = "pd", vars_to_exclude,
     features_to_bin <- intersect(features_to_bin, vars_to_include)
   }
 
-  mivs <- map(features_to_bin, function(name) calculate_miv(dframe, name, y, pd)) %>%
+  mivs <- map(features_to_bin, function(feature) calculate_miv(dframe, feature, y, predictions)) %>%
     setNames(features_to_bin)
 
   if(!as_dframe){
@@ -26,7 +27,7 @@ calculate_all_mivs <- function(dframe, y, pd = "pd", vars_to_exclude,
   arrange(desc(miv))
 }
 
-calculate_miv <- function(dframe, binned_x, y, pd = "pd"){
+calculate_miv <- function(dframe, binned_x, y, predictions){
   feature_is_categorical <- dframe[[binned_x]] %>% {is.character(.) | is.factor(.)}
 
   if(!feature_is_categorical){
@@ -35,7 +36,7 @@ calculate_miv <- function(dframe, binned_x, y, pd = "pd"){
 
   miv_tables <- dframe %>%
     rename_(group = binned_x) %>%
-    build_miv_tables(y, pd)
+    build_miv_tables(y, predictions)
 
   c(miv_tables, iv = sum(miv_tables$miv_table$iv), miv = sum(miv_tables$miv_table$miv))
 }

--- a/tests/testthat/test_calculate_all_mivs.R
+++ b/tests/testthat/test_calculate_all_mivs.R
@@ -4,13 +4,12 @@ credit_data_small <- german_credit_data %>%
 candidate_model <- glm(gb12 ~ ca_status, data = credit_data_small,
                        family = binomial)
 
-credit_data_w_pd <- credit_data_small %>%
-  mutate(pd = predict(candidate_model, ., type = "response"))
+predictions <- predict(candidate_model, credit_data_small, type = "response")
 
 test_that("given a data frame with a response variable named gb12
            and pd predictions from a previous model,
            calculate_all_mivs calculates the marginal iv for all variables", {
-  miv_output <- calculate_all_mivs(credit_data_w_pd, y = "gb12")
+  miv_output <- calculate_all_mivs(credit_data_small, y = "gb12", predictions = predictions)
 
   expected_output <- data_frame(
     feature_name = c("credit_history", "purpose", "ca_status"),
@@ -24,25 +23,27 @@ test_that("given a data frame with a response variable named gb12
 test_that("the feature data types can be factor or character", {
   #current data types of features are all character
   #so we need to test a factor variable
-  credit_data_w_pd$purpose <- factor(credit_data_w_pd$purpose)
+  credit_data_small$purpose <- factor(credit_data_small$purpose)
 
-  expect_error(calculate_all_mivs(credit_data_w_pd, y = "gb12"), NA)
+  expect_error(calculate_all_mivs(credit_data_small, y = "gb12", predictions), NA)
 })
 
 test_that("if numeric variables are included an error is thrown", {
   numeric_col <- german_credit_data %>% select(duration)
 
-  credit_data_w_pd <- bind_rows(credit_data_w_pd, numeric_col)
+  credit_data_small <- bind_rows(credit_data_small, numeric_col)
 
   expect_error(
-    calculate_all_mivs(credit_data_w_pd, y = "gb12"),
+    calculate_all_mivs(credit_data_small, y = "gb12", predictions),
     "cannot calculate miv for a non-categorical variable"
   )
 })
 
 test_that("if as_dframe = FALSE a detailed output of the miv calculations
            is presented in list form", {
-  miv_output <- calculate_all_mivs(credit_data_w_pd, y = "gb12", as_dframe = FALSE)
+  miv_output <- calculate_all_mivs(credit_data_small, y = "gb12", predictions,
+                                   as_dframe = FALSE)
+
   expected_output_names <- c("actual_woe", "expected_woe",
                              "miv_table", "iv", "miv")
 
@@ -52,14 +53,17 @@ test_that("if as_dframe = FALSE a detailed output of the miv calculations
 })
 
 test_that("user can specify which variables are excluded in the calculation", {
-  miv_output <- calculate_all_mivs(credit_data_w_pd, y = "gb12", vars_to_exclude = "purpose")
+  miv_output <- calculate_all_mivs(credit_data_small, y = "gb12", predictions,
+                                   vars_to_exclude = "purpose")
+  
   expected_features_included <- c("credit_history", "ca_status")
 
   expect_equal(miv_output$feature_name, expected_features_included)
 })
 
 test_that("user can specify which variables are included in the calculation", {
-  miv_output <- calculate_all_mivs(credit_data_w_pd, y = "gb12", vars_to_include = c("ca_status", "purpose"))
+  miv_output <- calculate_all_mivs(credit_data_small, y = "gb12", predictions,
+                                   vars_to_include = c("ca_status", "purpose"))
 
   expected_features_included <- c("purpose", "ca_status")
 


### PR DESCRIPTION
This PR allows you to pass previous model prediction in as a vector instead of having to be on the df of the features